### PR TITLE
bugfix: versão do pact Broker

### DIFF
--- a/example/infraestructure/pact-broker-with-jenkins/docker-compose.yml
+++ b/example/infraestructure/pact-broker-with-jenkins/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             POSTGRES_DB: postgres
             
     pact-broker:
-        image: pactfoundation/pact-broker:2
+        image: pactfoundation/pact-broker:2.60.1.0
         ports:
             - "9292:9292"
         depends_on:

--- a/example/infraestructure/pact-broker-with-nginx/docker-compose.yml
+++ b/example/infraestructure/pact-broker-with-nginx/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: postgres
   pact-broker:
-    image: pactfoundation/pact-broker:2
+    image: pactfoundation/pact-broker:2.60.1.0
     links:
       - postgres
     environment:

--- a/example/infraestructure/pact-broker/docker-compose.yml
+++ b/example/infraestructure/pact-broker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_DB: postgres
 
   pact-broker:
-    image: pactfoundation/pact-broker:2
+    image: pactfoundation/pact-broker:2.60.1.0
     ports:
       - "9292:9292"
     depends_on:


### PR DESCRIPTION
Descrição do problema:
Erro ao fazer o download do Pact no lado do Provedor.

Como Reproduzir:
Utilizar Pact Broker v2.60.0. Executar validação de Pact no lado do Provedor.
 
Solução:
Fixar versão do Pact Broker p/ 2.60.1. Novas versões deverão ser testadas e alteradas manualmente para evitar problemas similares.

Referência: https://pact-foundation.slack.com/archives/C9VPNUJR2/p1599672900044100