### PR TITLE
Changed default Jest timeout

### DIFF
--- a/examples/node/one_consumer_one_provider/account-api/jest.config.js
+++ b/examples/node/one_consumer_one_provider/account-api/jest.config.js
@@ -123,7 +123,7 @@ export default {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./jest.setup.js'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/examples/node/one_consumer_one_provider/account-api/jest.setup.js
+++ b/examples/node/one_consumer_one_provider/account-api/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(15000);

--- a/examples/node/one_consumer_one_provider/client-api/jest.config.js
+++ b/examples/node/one_consumer_one_provider/client-api/jest.config.js
@@ -123,7 +123,7 @@ export default {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./jest.setup.js'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],

--- a/examples/node/one_consumer_one_provider/client-api/jest.setup.js
+++ b/examples/node/one_consumer_one_provider/client-api/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(15000);

--- a/examples/node/one_consumer_one_provider/client-api/package.json
+++ b/examples/node/one_consumer_one_provider/client-api/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "dev:server": "ts-node-dev --ignore-watch node_modules --transpileOnly src/server.ts",
+    "dev:server": "ts-node-dev --ignore-watch node_modules --transpile-only src/server.ts",
     "test": "jest",
     "pact:publish": "ts-node-dev src/pact/PublishPact.ts"
   },


### PR DESCRIPTION
Updated two occasionally issues on Node.js example ("one_consumer_one_provider").

- Changed default Jest timeout (increased to avoid timeout of 5000 MLS).
- Fixed flag "--transpileOnly" to "--transpile-only" (updated).